### PR TITLE
fixed automated commit credentials

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Configure Git Credentials
         run: |
           echo ${{ github.workspace }}
-          git config --local user.email "action@agithub.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "GitHub Actions"
         
       - name: Update Data
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Configure Git Credentials
         run: |
           echo ${{ github.workspace }}
-          git config --local user.email "action@agithub.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "GitHub Actions"
 
       - name: Update Data
         run: |


### PR DESCRIPTION
See: https://github.community/t/github-actions-bot-email-address/17204

Since the repository is relatively inactive, it'd probably be worth rebasing all previous commits by `actions@agithub.com` into the new address.

You're normally supposed to push commits with a GitHub token, but hey, that works too.